### PR TITLE
Stop freezing state

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ read and understood in minutes. Give it a try!
 
 - A store object is an `EventEmitter`. (Notice the pattern?)
 - The `store.state` property should only be mutated using `store.setState()` or `store.replaceState()`
-- The `store.state` property is frozen to ensure it is not directly mutated.
 - Emits a `'change'` event when the `state` changes. It uses shallow equality to test if `state` has changed similar to how PureRenderMixin works in React.
 - Works well with Immutable.js values as properties of `state`.
 - Should **never** contain async code.

--- a/lib/create-store.js
+++ b/lib/create-store.js
@@ -5,20 +5,18 @@ var EventEmitter = require('eventemitter3')
 var objEql = require('obj-eql')
 
 function createStore(obj) {
-  var store = assign(Object.create(EventEmitter.prototype), {
+  return assign(Object.create(EventEmitter.prototype), {
     state: {},
     setState: function(change) {
       this.replaceState(assign({}, this.state, change))
     },
     replaceState: function(newState) {
       if (!objEql(newState, this.state)) {
-        this.state = Object.freeze(newState)
+        this.state = newState
         this.emit('change')
       }
     }
   }, obj)
-  Object.freeze(store.state)
-  return store
 }
 
 module.exports = createStore

--- a/test/create-store.js
+++ b/test/create-store.js
@@ -26,19 +26,10 @@ describe('createStore(obj)', function() {
       store.should.have.property('bar', 2)
     })
 
-    it('has frozen state property', function() {
-      Object.isFrozen(store.state).should.be.true
-    })
-
     describe('.setState(change)', function() {
       it('assigns properties of change to store.state', function() {
         store.setState({foo: 'bar'})
         store.state.should.have.property('foo', 'bar')
-      })
-
-      it('updates state with a new frozen state', function() {
-        store.setState({foo: 'bar'})
-        Object.isFrozen(store.state).should.be.true
       })
 
       it('emits a change event', function() {
@@ -63,11 +54,6 @@ describe('createStore(obj)', function() {
         var expected = {bar: 'baz'}
         store.replaceState(expected)
         store.state.should.eql(expected)
-      })
-
-      it('updates state with a new frozen state', function() {
-        store.replaceState({foo: 'bar'})
-        Object.isFrozen(store.state).should.be.true
       })
 
       it('emits a change event', function() {


### PR DESCRIPTION
While freezing state is a nice idea, the performance hit of initially freezing
an object on every state change can cause issues.
